### PR TITLE
Adapt the termal boundary conditions

### DIFF
--- a/src/init_fields.f90
+++ b/src/init_fields.f90
@@ -62,7 +62,7 @@ module init_fields
    real(cp), public :: amp_s1,amp_s2,amp_v1,amp_b1,amp_xi1,amp_xi2
 
    !----- Entropy at CMB and ICB (input):
-   integer, public, parameter :: n_s_bounds=20
+   integer, public, parameter :: n_s_bounds=100
    real(cp), public :: s_bot(4*n_s_bounds)  ! input variables for tops,bots
    real(cp), public :: s_top(4*n_s_bounds)
    complex(cp), public, allocatable :: tops(:,:)

--- a/src/preCalculations.f90
+++ b/src/preCalculations.f90
@@ -413,7 +413,7 @@ contains
             botconduc = rho0(n_r_max)*kappa(n_r_max)*temp0(n_r_max)
          end if
 
-         if ( ktops == 1 .and. kbots == 1 ) then ! Fixed entropy
+         if ( ktops == 1 .and. kbots == 1 .and. ( tops(0,0) == 0.0_cp .and. bots(0,0) == 0.0_cp )) then ! Fixed entropy
 
             tops(0,0)=0.0_cp
             bots(0,0)=sq4pi


### PR DESCRIPTION
The changes to the termal boundary conditions enabes the uses of 100 coefficient of spherical harmonics. Also the set of mode l=0 and m=0 automatically to 1 is commented out, since this affects the BC set. Now the thermal BC s_top and s_bot need to be defined precisely.